### PR TITLE
Fix `mapm_block_chat` cvar

### DIFF
--- a/addons/amxmodx/scripting/map_manager_effects.sma
+++ b/addons/amxmodx/scripting/map_manager_effects.sma
@@ -92,7 +92,7 @@ public clcmd_say(id)
 
 	new args[2]; read_args(args, charsmax(args));
 
-	return (args[0] == '/') ? PLUGIN_HANDLED_MAIN : PLUGIN_HANDLED;
+	return (args[0] == '/') ? PLUGIN_HANDLED : PLUGIN_HANDLED_MAIN;
 }
 public player_spawn_post(id)
 {


### PR DESCRIPTION
It's better? Coz previous doesn't block chat msg via this plugins.ini order:
{mapmanager plugins....}
{gag_manager}
{chat_manager}