### PR TITLE
Add restrictions in cmd start and stop vote

### DIFF
--- a/cstrike/addons/amxmodx/scripting/map_manager_scheduler.sma
+++ b/cstrike/addons/amxmodx/scripting/map_manager_scheduler.sma
@@ -225,6 +225,10 @@ restore_limits()
 }
 public concmd_startvote(id, level, cid)
 {
+    if(is_vote_started() || is_vote_finished() || is_vote_will_in_next_round()) {
+        return PLUGIN_HANDLED;
+    }
+
     if(!cmd_access(id, level, cid, 1)) {
         return PLUGIN_HANDLED;
     }
@@ -238,6 +242,10 @@ public concmd_startvote(id, level, cid)
 }
 public concmd_stopvote(id, level, cid)
 {
+    if(is_vote_finished()) {
+        return PLUGIN_HANDLED;
+    }
+
     if(!cmd_access(id, level, cid, 1)) {
         return PLUGIN_HANDLED;
     }


### PR DESCRIPTION
We need to add restrictions in cmd start and stop vote. Now they can cause bugs.
For example: the voting is starts in new round. If now make `mapm_stop_vote`, then `mp_timelimit` will stay "0"