### PR TITLE
Fix protruding images in hi-res

### DIFF
--- a/cstrike/addons/amxmodx/scripting/map_manager_gui.sma
+++ b/cstrike/addons/amxmodx/scripting/map_manager_gui.sma
@@ -174,6 +174,15 @@ public plugin_precache()
     g_vecPOVOrigin = origin;
 
     // TODO: Move offsets to defines
+    /*******
+    *** Fix protruding images outside the monitor in more than 1920x1080 resolution
+    ***
+    *** origin[0] += 170.0;
+    *** origin[1] += 90.0;
+    *** origin[2] += 48.0;
+    ***
+    *******/
+    
     origin[0] += 144.0;
     origin[1] += 96.0;
     origin[2] += 48.0;


### PR DESCRIPTION
Scale image in config files is not enough at high resolutions (e.g. 3840 × 2160). I'm tested value from 0.1 to 1.0 in config and not working, this pr added tested values which works fine.