### PR TITLE
Fix calling forward `server_changelevel()`

### DIFF
--- a/cstrike/addons/amxmodx/scripting/map_manager_scheduler.sma
+++ b/cstrike/addons/amxmodx/scripting/map_manager_scheduler.sma
@@ -425,7 +425,7 @@ public delayed_change()
 {
     new nextmap[MAPNAME_LENGTH]; get_string(NEXTMAP, nextmap, charsmax(nextmap));
     set_float(CHATTIME, get_float(CHATTIME) - 1.0);
-    server_cmd("changelevel %s", nextmap);
+    engine_changelevel(nextmap);
 }
 planning_vote(type)
 {

--- a/cstrike/addons/amxmodx/scripting/map_manager_scheduler.sma
+++ b/cstrike/addons/amxmodx/scripting/map_manager_scheduler.sma
@@ -9,7 +9,7 @@
 #endif
 
 #define PLUGIN "Map Manager: Scheduler"
-#define VERSION "0.2.1"
+#define VERSION "0.2.2"
 #define AUTHOR "Mistrick"
 
 #pragma semicolon 1


### PR DESCRIPTION
https://www.amxmodx.org/api/amxmodx/server_changelevel

>This is *only* called if the mod itself handles the map change. The
server command "changelevel", which is used by many plugins, will not
trigger this forward. Unfortunately, this means that in practice this
forward can be unreliable and will not be called in many situations.

>AMXX 1.8.3 has added the engine_changelevel() function, which will utilize
the correct engine function to change the map, and therefore trigger
this forward.